### PR TITLE
Feat/주문 API 구현 

### DIFF
--- a/src/controllers/cartController.ts
+++ b/src/controllers/cartController.ts
@@ -11,16 +11,18 @@ import { UpdateCartItemRequestDTO } from '../dto/cartDTO';
 import { UpdateCartItemStruct } from '../structs/cartStruct';
 import { validate } from 'superstruct';
 import BadRequestError from '../lib/errors/BadRequestError';
+import UnauthorizedError from '../lib/errors/UnauthorizedError';
 
 export const createCartController = async (req: Request, res: Response) => {
-  const buyerId = req.user!.id;
+  if (!req.user) throw new UnauthorizedError('인증되지 않은 유저입니다.');
+  const buyerId = req.user.id;
   const cart = await createCartService(buyerId);
   res.status(201).json(cart);
 };
 
 export const getCartListController = async (req: Request, res: Response) => {
-
-  const buyerId = req.user!.id;
+  if (!req.user) throw new UnauthorizedError('인증되지 않은 유저입니다.');
+  const buyerId = req.user.id;
 
   const cart = await getCartListService(buyerId);
   const response = serializeCart(cart);
@@ -29,10 +31,9 @@ export const getCartListController = async (req: Request, res: Response) => {
 };
 
 export const updateCartItemController = async (req: Request, res: Response) => {
-
   const [error] = validate(req.body, UpdateCartItemStruct);
 
-  if (error) throw new BadRequestError('유효하지 않은 요청입니다.')
+  if (error) throw new BadRequestError(`요청 데이터가 유효하지 않습니다: ${error.message}`);
 
   const updateData: UpdateCartItemRequestDTO = req.body;
   const updatedItem = await updateCartItemService(updateData);

--- a/src/controllers/orderController.ts
+++ b/src/controllers/orderController.ts
@@ -1,0 +1,70 @@
+import { Request, Response } from 'express';
+import {
+  createOrderService,
+  deleteOrderService,
+  getOrderByIdService,
+  getOrderListService,
+  updateOrderService,
+} from '../services/orderService';
+import { CreateOrderStuct, OrderParamsStruct, UpdateOrderStruct } from '../structs/orderStructs';
+import { create } from 'superstruct';
+import { serializeOrder } from '../lib/utils/serializeOrder';
+import UnauthorizedError from '../lib/errors/UnauthorizedError';
+import BadRequestError from '../lib/errors/BadRequestError';
+import { validate } from 'superstruct';
+import { OrderRequestDTO, OrderUpdateRequestDTO } from '../dto/orderDTO';
+
+export const createOrderController = async (req: Request, res: Response) => {
+  if (!req.user) throw new UnauthorizedError('인증되지 않은 유저입니다.');
+  const userId = req.user.id;
+
+  const [error] = validate(req.body, CreateOrderStuct);
+
+  if (error) throw new BadRequestError(`요청 데이터가 유효하지 않습니다: ${error.message}`);
+
+  const orderData: OrderRequestDTO = {
+    ...req.body,
+    userId,
+  };
+  const createdOrder = await createOrderService(orderData, userId);
+  const reponse = serializeOrder(createdOrder);
+  res.status(201).json(reponse);
+};
+
+export const getOrderListController = async (req: Request, res: Response) => {
+  if (!req.user) throw new UnauthorizedError('인증되지 않은 유저입니다.');
+  const userId = req.user.id;
+
+  const params = create(req.query, OrderParamsStruct);
+  const order = await getOrderListService(userId, params);
+  res.status(200).json(order);
+};
+
+export const getOrderByIdController = async (req: Request, res: Response) => {
+  const orderId = req.params.id;
+  const order = await getOrderByIdService(orderId);
+  res.status(200).json(order);
+};
+
+export const updateOrderController = async (req: Request, res: Response) => {
+  const [error] = validate(req.body, UpdateOrderStruct);
+
+  if (error) throw new BadRequestError(`요청 데이터가 유효하지 않습니다: ${error.message}`);
+
+  const updateData:OrderUpdateRequestDTO = req.body;
+  if (!req.user) throw new UnauthorizedError('인증되지 않은 유저입니다.');
+
+  const userId = req.user.id;
+  const orderId = req.params.id;
+
+  const updateOrder = await updateOrderService(updateData, orderId, userId);
+  const response = serializeOrder(updateOrder);
+  res.status(200).json(response);
+};
+
+export const deleteOrderController = async (req: Request, res: Response) => {
+  const orderId = req.params.id;
+
+  await deleteOrderService(orderId);
+  return res.status(204).send();
+};

--- a/src/dto/cartDTO.ts
+++ b/src/dto/cartDTO.ts
@@ -21,7 +21,7 @@ export interface CartItemResponseDTO {
   quantity: number;
   createdAt: Date;
   updatedAt: Date;
-  product: ProductResponseDTO;
+  product: CartProductResponseDTO;
 }
 
 export interface CartItemWithCartResponseDTO {
@@ -32,11 +32,11 @@ export interface CartItemWithCartResponseDTO {
   quantity: number;
   createdAt: Date;
   updatedAt: Date;
-  product: ProductResponseDTO;
+  product: CartProductResponseDTO;
   cart: CartItemWithCartDTO;
 }
 
-export interface ProductResponseDTO {
+export interface CartProductResponseDTO {
   id: string;
   storeId: string;
   name: string;
@@ -47,11 +47,11 @@ export interface ProductResponseDTO {
   discountEndTime: Date | null;
   createdAt: Date;
   updatedAt: Date;
-  store: StoreResponseDTO;
-  stocks: StocksResponseDTO[];
+  store: CartStoreResponseDTO;
+  stocks: CartStocksResponseDTO[];
 }
 
-export interface StoreResponseDTO {
+export interface CartStoreResponseDTO {
   id: string;
   userId: string;
   name: string;
@@ -63,15 +63,15 @@ export interface StoreResponseDTO {
   updatedAt: Date;
 }
 
-export interface StocksResponseDTO {
+export interface CartStocksResponseDTO {
   id: string;
   productId: string;
   sizeId: string;
   quantity: number;
-  size: SizeResponseDTO;
+  size: CartSizeResponseDTO;
 }
 
-export interface SizeResponseDTO {
+export interface CartSizeResponseDTO {
   id: string;
   size: string | number | boolean | { en?: string; ko?: string } | null | Array<any>;
 }

--- a/src/dto/orderDTO.ts
+++ b/src/dto/orderDTO.ts
@@ -1,0 +1,100 @@
+import { PaymentStatus } from '@prisma/client';
+
+export interface OrderRequestDTO {
+  userId: string;
+  name: string;
+  phoneNumber: string;
+  address: string;
+  orderItems: OrderItemRequestDTO[];
+  usePoint: number;
+}
+
+export interface OrderItemRequestDTO {
+  productId: string;
+  sizeId: string;
+  quantity: number;
+}
+
+export interface OrderUpdateRequestDTO {
+  name: string;
+  phoneNumber: string;
+  address: string;
+  orderItems: OrderItemUpdateRequestDTO[];
+  usePoint: number;
+}
+
+export interface OrderItemUpdateRequestDTO extends OrderItemRequestDTO {
+  price: number;
+}
+
+export interface OrderResponseDTO {
+  id: string;
+  name: string;
+  phoneNumber: string;
+  address: string;
+  subtotal: number;
+  totalQuantity: number;
+  usePoint: number;
+  createdAt: Date;
+  orderItems: OrderItemResponseDTO[];
+  payments: PaymentsResponseDTO | null;
+}
+
+export interface OrderItemResponseDTO {
+  id: string;
+  price: number;
+  quantity: number;
+  productId: string;
+  product: OrderProductResponseDTO;
+  size: OrderSizeResponseDTO;
+  isReviewed: boolean;
+}
+
+export interface OrderProductResponseDTO {
+  id: string;
+  storeId: string;
+  name: string;
+  price: number;
+  image: string;
+  discountRate: number;
+  discountStartTime: Date | null;
+  discountEndTime: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+  store: OrderStoreResponseDTO;
+  stocks: OrderStocksResponseDTO[];
+}
+
+export interface OrderStoreResponseDTO {
+  id: string;
+  userId: string;
+  name: string;
+  address: string;
+  phoneNumber: string;
+  content: string;
+  image: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface OrderStocksResponseDTO {
+  id: string;
+  productId: string;
+  sizeId: string;
+  quantity: number;
+  size: OrderSizeResponseDTO;
+}
+
+export interface OrderSizeResponseDTO {
+  id: string;
+  size: string | number | boolean | { en?: string; ko?: string } | null | Array<any>;
+}
+
+export interface PaymentsResponseDTO {
+  id: string;
+  price: number;
+  status: PaymentStatus;
+  createdAt: Date;
+  updatedAt: Date;
+  orderId: string;
+}

--- a/src/lib/utils/cartTestUtil.ts
+++ b/src/lib/utils/cartTestUtil.ts
@@ -32,7 +32,7 @@ export const sellerUserData = {
 export const storeData = {
   id: 'storeId',
   name: '너이키',
-  userId: buyerUserData.id,
+  userId: sellerUserData.id,
   address: '서울',
   phoneNumber: '123-1234',
   content: '스포츠 용품',

--- a/src/lib/utils/orderTestUtil.ts
+++ b/src/lib/utils/orderTestUtil.ts
@@ -1,0 +1,164 @@
+import { GradeName, CategoryName, PaymentStatus, UserType } from '@prisma/client';
+import { prismaClient } from '../../lib/prismaClient';
+import bcrypt from 'bcrypt';
+import app from '../../app';
+import request from 'supertest';
+
+export const gradeData = {
+  id: 'grade_green',
+  name: GradeName.Green,
+  rate: 5,
+  minAmount: 100000,
+};
+
+export const buyerUserData = {
+  id: 'userId',
+  name: '테스트Buyer',
+  email: 'test@example.com',
+  password: 'password',
+  image: null,
+  type: UserType.BUYER,
+  points: 10000
+};
+
+export const sellerUserData = {
+  id: 'userId2',
+  name: '테스트Seller',
+  email: 'test2@example.com',
+  password: 'password',
+  image: null,
+  type: UserType.SELLER,
+};
+
+export const storeData = {
+  id: 'storeId',
+  name: '너이키',
+  userId: sellerUserData.id,
+  address: '서울',
+  phoneNumber: '123-1234',
+  content: '스포츠 용품',
+  image: 'imageURL',
+};
+
+export const categoryData = {
+  id: 'categoryId',
+  name: CategoryName.BOTTOM,
+};
+
+export const productData = {
+  id: 'productId',
+  storeId: storeData.id,
+  categoryId: categoryData.id,
+  name: '청바지',
+  price: 25000,
+  image: 'imageURL',
+  discountRate: 10,
+  discountStartTime: '2025-06-17T01:49:11.128Z',
+  discountEndTime: '2025-06-27T01:49:11.128Z',
+};
+
+export const sizeData = {
+  id: 'sizeId',
+  name: 'L',
+  size: { en: 'L', ko: '라지' },
+};
+
+export const stockData = {
+  id: 'stockId',
+  productId: productData.id,
+  sizeId: sizeData.id,
+  quantity: 100,
+};
+
+export const cartData = {
+  id: 'cartId',
+  buyerId: buyerUserData.id,
+};
+
+export const cartItemData = {
+  id: 'cartItemId',
+  cartId: cartData.id,
+  productId: productData.id,
+  sizeId: sizeData.id,
+};
+
+export const orderData = {
+  id: 'orderId',
+  userId: buyerUserData.id,
+  name: '홍길동',
+  phoneNumber: '010-1234-1234',
+  address: '천안',
+  subtotal: 45000,
+  totalQuantity: 2,
+  usePoint: 1000,
+};
+
+export const orderItemData = {
+  id: 'orderItemId',
+  price: 22500,
+  quantity: 2,
+  productId: productData.id,
+  sizeId: sizeData.id,
+  orderId: orderData.id,
+};
+
+export const paymentData = {
+  id: 'paymentId',
+  price: 44000,
+  status: PaymentStatus.CompletedPayment,
+  orderId: orderData.id,
+};
+
+export const seedTestData = async () => {
+  const hashedBuyerPassword = await bcrypt.hash(buyerUserData.password, 10);
+  const hashedSellerPassword = await bcrypt.hash(sellerUserData.password, 10);
+
+  await prismaClient.$transaction([
+    prismaClient.grade.create({ data: gradeData }),
+    prismaClient.user.create({ data: { ...buyerUserData, password: hashedBuyerPassword } }),
+    prismaClient.user.create({ data: { ...sellerUserData, password: hashedSellerPassword } }),
+    prismaClient.store.create({ data: storeData }),
+    prismaClient.category.create({ data: categoryData }),
+    prismaClient.product.create({ data: productData }),
+    prismaClient.size.create({ data: sizeData }),
+    prismaClient.stock.create({ data: stockData }),
+  ]);
+};
+
+export const seedOrderTestData = async () => {
+  await prismaClient.$transaction([
+    prismaClient.order.create({ data: orderData }),
+    prismaClient.orderItem.create({ data: orderItemData }),
+    prismaClient.payment.create({ data: paymentData }),
+  ]);
+};
+
+export const buyerUserLogin = async () => {
+  const agent = request.agent(app);
+
+  const res = await agent.post('/api/auth/login').send({
+    email: buyerUserData.email,
+    password: buyerUserData.password,
+  });
+
+  const token = res.body.accessToken;
+
+  agent.set('Authorization', `Bearer ${token}`);
+
+  return { agent };
+};
+
+export const sellerUserLogin = async () => {
+  const agent = request.agent(app);
+
+  const res = await agent.post('/api/auth/login').send({
+    email: sellerUserData.email,
+    password: sellerUserData.password,
+  });
+
+  const token = res.body.accessToken;
+
+  agent.set('Authorization', `Bearer ${token}`);
+
+  return { agent };
+};

--- a/src/lib/utils/serializeCart.ts
+++ b/src/lib/utils/serializeCart.ts
@@ -2,7 +2,7 @@ import {
   CartResponseDTO,
   CartItemResponseDTO,
   CartItemWithCartResponseDTO,
-  StocksResponseDTO,
+  CartStocksResponseDTO,
 } from '../../dto/cartDTO';
 
 export function serializeCart(cart: CartResponseDTO) {
@@ -41,7 +41,7 @@ export function serializeCart(cart: CartResponseDTO) {
           createdAt: item.product.store.createdAt,
           updatedAt: item.product.store.updatedAt,
         },
-        stocks: item.product.stocks.map((stock: StocksResponseDTO) => {
+        stocks: item.product.stocks.map((stock: CartStocksResponseDTO) => {
           const sizeValue = stock.size.size;
           const isSizeObj =
             typeof sizeValue === 'object' && sizeValue !== null && !Array.isArray(sizeValue);
@@ -96,7 +96,7 @@ export function serializeCartItem(cartItem: CartItemWithCartResponseDTO) {
         createdAt: cartItem.product.store.createdAt,
         updatedAt: cartItem.product.store.updatedAt,
       },
-      stocks: cartItem.product.stocks.map((stock: StocksResponseDTO) => {
+      stocks: cartItem.product.stocks.map((stock: CartStocksResponseDTO) => {
         const sizeValue = stock.size.size;
         const isSizeObj =
           typeof sizeValue === 'object' && sizeValue !== null && !Array.isArray(sizeValue);

--- a/src/lib/utils/serializeOrder.ts
+++ b/src/lib/utils/serializeOrder.ts
@@ -1,0 +1,65 @@
+import { OrderResponseDTO,OrderItemResponseDTO, OrderStocksResponseDTO } from "../../dto/orderDTO";
+
+export function serializeOrder(order: OrderResponseDTO){
+  return {
+    id: order.id,
+    name: order.name,
+    phoneNumber: order.phoneNumber,
+    address: order.address,
+    subtotal: order.subtotal,
+    totalQuantity: order.totalQuantity,
+    usePoint: order.usePoint,
+    createdAt: order.createdAt,
+    orderItems: order.orderItems.map((orderItem: OrderItemResponseDTO)=>({
+      id: orderItem.id,
+      price: orderItem.price,
+      quantity: orderItem.quantity,
+      productId: orderItem.productId,
+      product:{
+        id: orderItem.product.id,
+        storeId: orderItem.product.storeId,
+        name: orderItem.product.name,
+        price: orderItem.product.price,
+        image: orderItem.product.image,
+        discountRate: orderItem.product.discountRate,
+        discountStartTime: orderItem.product.discountStartTime,
+        discountEndTime: orderItem.product.discountEndTime,
+        createdAt: orderItem.product.createdAt,
+        updatedAt: orderItem.product.updatedAt,
+        store: {
+          id: orderItem.product.store.id,
+          userId: orderItem.product.store.userId,
+          name: orderItem.product.store.name,
+          address: orderItem.product.store.address,
+          phoneNumber: orderItem.product.store.phoneNumber,
+          content: orderItem.product.store.content,
+          image: orderItem.product.store.image,
+          createdAt: orderItem.product.store.createdAt,
+          updatedAt: orderItem.product.store.updatedAt,
+        },
+        stocks: orderItem.product.stocks.map((stock:OrderStocksResponseDTO)=>{
+          const sizeValue = stock.size.size;
+          const isSizeObj =
+          typeof sizeValue === 'object' && sizeValue !== null && !Array.isArray(sizeValue);
+
+          return {
+            id: stock.id,
+            productId: stock.productId,
+            sizeId: stock.sizeId,
+            quantity: stock.quantity,
+            size: {
+              id: stock.size.id,
+              size: {
+                en: isSizeObj ? (sizeValue.en ?? '') : '',
+                ko: isSizeObj ? (sizeValue.ko ?? '') : '',
+              },
+            },
+          };
+        }),
+      },
+      isReviewed: orderItem.isReviewed,
+    })),
+    payments: order.payments,
+  };
+}
+

--- a/src/repositories/orderRepository.ts
+++ b/src/repositories/orderRepository.ts
@@ -1,0 +1,290 @@
+import { prismaClient } from '../lib/prismaClient';
+import { PaymentStatus } from '@prisma/client';
+import {
+  CreateOrderWithExtras,
+  OrderList,
+  PaginatedOrderList,
+  PaginationParams,
+  updateOrderData,
+} from '../types/order';
+
+export const findUserId = async (userId: string) => {
+  const user = await prismaClient.user.findUnique({
+    where: { id: userId },
+  });
+  return user;
+};
+
+export const findProductByPrice = async (productId: string[]) => {
+  const product = await prismaClient.product.findMany({
+    where: { id: { in: productId } },
+    select: { id: true, price: true },
+  });
+  return product.reduce<Record<string, number>>((acc, cur) => {
+    acc[cur.id] = cur.price;
+    return acc;
+  }, {});
+};
+
+export const createOrder = async (data: CreateOrderWithExtras) => {
+  return await prismaClient.$transaction(async (tx) => {
+    for (const item of data.orderItems) {
+      const updated = await tx.stock.updateMany({
+        where: {
+          productId: item.productId,
+          sizeId: item.sizeId,
+          quantity: { gte: item.quantity },
+        },
+        data: {
+          quantity: {
+            decrement: item.quantity,
+          },
+        },
+      });
+      if (updated.count === 0) {
+        throw new Error('재고가 부족합니다');
+      }
+    }
+
+    if (data.usePoint > 0) {
+      const updated = await tx.user.updateMany({
+        where: {
+          id: data.userId,
+          points: { gte: data.usePoint },
+        },
+        data: {
+          points: { decrement: data.usePoint },
+        },
+      });
+      if (updated.count === 0) {
+        throw new Error('포인트가 부족합니다.');
+      }
+    }
+
+    const order = await tx.order.create({
+      data: {
+        user: { connect: { id: data.userId } },
+        name: data.name,
+        phoneNumber: data.phoneNumber,
+        address: data.address,
+        subtotal: data.subtotal,
+        totalQuantity: data.totalQuantity,
+        usePoint: data.usePoint,
+        orderItems: {
+          create: data.orderItems.map((item) => {
+            const price = data.priceMap[item.productId];
+            if (price == null) throw new Error('상품 가격을 찾을 수 없습니다');
+            return {
+              product: { connect: { id: item.productId } },
+              size: { connect: { id: item.sizeId } },
+              quantity: item.quantity,
+              price: price,
+            };
+          }),
+        },
+        payments: {
+          create: {
+            price: data.subtotal - data.usePoint,
+            status: PaymentStatus.CompletedPayment,
+          },
+        },
+      },
+      include: {
+        orderItems: {
+          include: {
+            product: {
+              include: {
+                store: true,
+                stocks: {
+                  include: {
+                    size: true,
+                  },
+                },
+              },
+            },
+            size: true,
+          },
+        },
+        payments: true,
+      },
+    });
+    const salesLogData = order.orderItems.map((item) => ({
+      productId: item.productId,
+      storeId: item.product.storeId,
+      userId: order.userId,
+      price: item.price,
+      quantity: item.quantity,
+      soldAt: new Date(),
+    }));
+    await tx.salesLog.createMany({
+      data: salesLogData,
+    });
+    return order;
+  });
+};
+
+export const getOrderList = async (
+  userId: string,
+  { page, pageSize, status = PaymentStatus.CompletedPayment, orderBy }: PaginationParams,
+): Promise<PaginatedOrderList> => {
+  const order = orderBy === 'oldest' ? 'asc' : 'desc';
+
+  const [orders, total] = await Promise.all([
+    prismaClient.order.findMany({
+      where: {
+        userId,
+        ...(status && {
+          payments: {
+            status: status,
+          },
+        }),
+      },
+      orderBy: { createdAt: order },
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+      include: {
+        orderItems: {
+          include: {
+            product: {
+              include: {
+                store: true,
+                stocks: {
+                  include: {
+                    size: true,
+                  },
+                },
+              },
+            },
+            size: true,
+          },
+        },
+        payments: true,
+      },
+    }),
+    prismaClient.order.count({
+      where: {
+        userId,
+        ...(status && {
+          payments: {
+            status: status,
+          },
+        }),
+      },
+    }),
+  ]);
+  const totalPages = Math.ceil(total / pageSize);
+
+  return {
+    data: orders,
+    meta: {
+      limit: pageSize,
+      page,
+      total,
+      totalPages,
+    },
+  };
+};
+
+export const getOrderById = async (orderId: string): Promise<OrderList | null> => {
+  return await prismaClient.order.findUnique({
+    where: { id: orderId },
+    include: {
+      orderItems: {
+        include: {
+          product: {
+            include: {
+              store: true,
+              stocks: {
+                include: {
+                  size: true,
+                },
+              },
+            },
+          },
+          size: true,
+        },
+      },
+      payments: true,
+    },
+  });
+};
+
+export const updateOrder = async (
+  updateData: updateOrderData,
+  orderId: string,
+  priceMap: Record<string, number>,
+): Promise<OrderList> => {
+  return await prismaClient.$transaction(async (tx) => {
+    return await tx.order.update({
+      where: { id: orderId },
+      data: {
+        name: updateData.name,
+        phoneNumber: updateData.phoneNumber,
+        address: updateData.address,
+        usePoint: updateData.usePoint,
+        orderItems: {
+          deleteMany: {},
+          create: updateData.orderItems.map((item) => ({
+            product: { connect: { id: item.productId } },
+            size: { connect: { id: item.sizeId } },
+            quantity: item.quantity,
+            price: priceMap[item.productId],
+          })),
+        },
+      },
+      include: {
+        orderItems: {
+          include: {
+            product: {
+              include: {
+                store: true,
+                stocks: {
+                  include: {
+                    size: true,
+                  },
+                },
+              },
+            },
+            size: true,
+          },
+        },
+        payments: true,
+      },
+    });
+  });
+};
+
+export const findOrderById = async (orderId: string) => {
+  return await prismaClient.order.findUnique({
+    where: { id: orderId },
+  });
+};
+
+export const findUsePoint = async (userId: string): Promise<number | null> => {
+  const user = await prismaClient.user.findUnique({
+    where: { id: userId },
+    select: {
+      points: true,
+    },
+  });
+  return user ? user.points : null;
+};
+
+export const deleteOrder = async (orderId: string) => {
+  return await prismaClient.order.delete({
+    where: { id: orderId },
+  });
+};
+
+export const findPaymentByStatus = async (orderId: string) => {
+  return await prismaClient.order.findUnique({
+    where: { id: orderId },
+    include: {
+      payments: {
+        select: {
+          status: true,
+        },
+      },
+    },
+  });
+};

--- a/src/routers/cartRouter.test.ts
+++ b/src/routers/cartRouter.test.ts
@@ -2,26 +2,12 @@ import request from 'supertest';
 import app from '../app';
 import { clearDatabase } from '../lib/testUtils';
 import { prismaClient } from '../lib/prismaClient';
-import {
-  gradeData,
-  buyerUserData,
-  storeData,
-  categoryData,
-  productData,
-  sizeData,
-  stockData,
-  cartData,
-  cartItemData,
-  seedTestData,
-  seedCartTestData,
-  buyerUserLogin,
-  sellerUserLogin,
-} from '../lib/utils/cartTestUtil';
+import * as cartTestUtil from '../lib/utils/cartTestUtil';
 
 describe('장바구니 API 테스트', () => {
   beforeEach(async () => {
     await clearDatabase(prismaClient);
-    await seedTestData();
+    await cartTestUtil.seedTestData();
   });
 
   afterAll(async () => {
@@ -30,149 +16,149 @@ describe('장바구니 API 테스트', () => {
 
   describe('POST /api/cart', () => {
     test.skip('필수 값이 누락되면 400을 반환한다', async () => {
-      const { agent } = await buyerUserLogin();
+      const { agent } = await cartTestUtil.buyerUserLogin();
       const response = await agent.post('/api/cart').send({ buyerId: null });
       expect(response.status).toBe(400);
       expect(response.body.message).toBe('buyerId가 존재하지 않습니다.');
     });
 
     test('인증되지 않은 유저는 401을 반환한다', async () => {
-      const response = await request(app).post('/api/cart').send(cartData);
+      const response = await request(app).post('/api/cart').send(cartTestUtil.cartData);
       expect(response.status).toBe(401);
     });
 
     test('접근 권한이 없는 유저는 403을 반환한다', async () => {
-      const { agent } = await sellerUserLogin();
-      const response = await agent.post('/api/cart').send(cartData);
+      const { agent } = await cartTestUtil.sellerUserLogin();
+      const response = await agent.post('/api/cart').send(cartTestUtil.cartData);
       expect(response.status).toBe(403);
     });
     test('장바구니 등록에 성공하면 201을 반환한다', async () => {
-      const { agent } = await buyerUserLogin();
-      const response = await agent.post('/api/cart').send(cartData);
+      const { agent } = await cartTestUtil.buyerUserLogin();
+      const response = await agent.post('/api/cart').send(cartTestUtil.cartData);
       expect(response.status).toBe(201);
       expect(response.body).toMatchObject({
         id: expect.any(String),
-        buyerId: buyerUserData.id,
+        buyerId: cartTestUtil.buyerUserData.id,
       });
     });
 
     describe('GET /api/cart', () => {
       test.skip('필수 값이 누락되면 400을 반환한다', async () => {
-        const { agent } = await buyerUserLogin();
+        const { agent } = await cartTestUtil.buyerUserLogin();
         const response = await agent.get('/api/cart');
         expect(response.status).toBe(400);
       });
 
       test('인증되지 않은 유저는 401을 반환한다', async () => {
-        await seedCartTestData();
+        await cartTestUtil.seedCartTestData();
         const response = await request(app).get('/api/cart');
         expect(response.status).toBe(401);
       });
 
       test('접근 권한이 없는 유저는 403을 반환한다', async () => {
-        const { agent } = await sellerUserLogin();
+        const { agent } = await cartTestUtil.sellerUserLogin();
         const response = await agent.get('/api/cart');
         expect(response.status).toBe(403);
       });
 
       test('존재하지 않는 장바구니를 조회하면 404를 반환한다', async () => {
-        const { agent } = await buyerUserLogin();
+        const { agent } = await cartTestUtil.buyerUserLogin();
         const response = await agent.get('/api/cart');
 
         expect(response.status).toBe(404);
       });
 
       test('장바구니 조회에 성공하면 200을 반환한다', async () => {
-        await seedCartTestData();
+        await cartTestUtil.seedCartTestData();
 
-        const { agent } = await buyerUserLogin();
+        const { agent } = await cartTestUtil.buyerUserLogin();
         const response = await agent.get('/api/cart');
 
         expect(response.status).toBe(200);
 
         expect(response.body).toMatchObject({
-          id: cartData.id,
-          buyerId: cartData.buyerId,
+          id: cartTestUtil.cartData.id,
+          buyerId: cartTestUtil.cartData.buyerId,
           items: expect.any(Array),
         });
 
         expect(response.body.items.length).toBeGreaterThan(0);
 
         expect(response.body.items[0]).toMatchObject({
-          id: cartItemData.id,
-          productId: cartItemData.productId,
-          sizeId: cartItemData.sizeId,
+          id: cartTestUtil.cartItemData.id,
+          productId: cartTestUtil.cartItemData.productId,
+          sizeId: cartTestUtil.cartItemData.sizeId,
         });
       });
     });
     describe('PATCH /api/cart', () => {
       const updateData = {
-        cartId: cartItemData.cartId,
-        productId: cartItemData.productId,
-        sizeId: cartItemData.sizeId,
+        cartId: cartTestUtil.cartItemData.cartId,
+        productId: cartTestUtil.cartItemData.productId,
+        sizeId: cartTestUtil.cartItemData.sizeId,
         quantity: 5,
       };
 
       test('장바구니에 담는 수량이 재고보다 초과하면 400을 반환한다', async () => {
         const NotFoundUpdateData = {
-          cartId: cartItemData.cartId,
-          productId: cartItemData.productId,
-          sizeId: cartItemData.sizeId,
+          cartId: cartTestUtil.cartItemData.cartId,
+          productId: cartTestUtil.cartItemData.productId,
+          sizeId: cartTestUtil.cartItemData.sizeId,
           quantity: 200,
         };
-        await seedCartTestData();
-        const { agent } = await buyerUserLogin();
+        await cartTestUtil.seedCartTestData();
+        const { agent } = await cartTestUtil.buyerUserLogin();
         const response = await agent.patch('/api/cart').send(NotFoundUpdateData);
         expect(response.status).toBe(400);
       });
 
       test('인증되지 않은 유저는 401을 반환한다', async () => {
-        await seedCartTestData();
+        await cartTestUtil.seedCartTestData();
         const response = await request(app).patch('/api/cart').send(updateData);
         expect(response.status).toBe(401);
       });
 
       test('접근 권한이 없는 유저는 403을 반환한다', async () => {
-        await seedCartTestData();
-        const { agent } = await sellerUserLogin();
+        await cartTestUtil.seedCartTestData();
+        const { agent } = await cartTestUtil.sellerUserLogin();
         const response = await agent.patch('/api/cart').send(updateData);
         expect(response.status).toBe(403);
       });
 
       test('장바구니에 상품을 추가하거나 수정하면 200을 반환한다', async () => {
-        await seedCartTestData();
-        const { agent } = await buyerUserLogin();
+        await cartTestUtil.seedCartTestData();
+        const { agent } = await cartTestUtil.buyerUserLogin();
         const response = await agent.patch('/api/cart').send(updateData);
 
         expect(response.status).toBe(200);
 
         const updatedItem = response.body;
         expect(updatedItem).toMatchObject({
-          id: cartItemData.id,
-          cartId: cartData.id,
-          productId: productData.id,
-          sizeId: sizeData.id,
+          id: cartTestUtil.cartItemData.id,
+          cartId: cartTestUtil.cartData.id,
+          productId: cartTestUtil.productData.id,
+          sizeId: cartTestUtil.sizeData.id,
           quantity: expect.any(Number),
           product: {
-            id: productData.id,
-            storeId: storeData.id,
-            name: productData.name,
-            price: productData.price,
-            image: productData.image,
-            discountRate: productData.discountRate,
+            id: cartTestUtil.productData.id,
+            storeId: cartTestUtil.storeData.id,
+            name: cartTestUtil.productData.name,
+            price: cartTestUtil.productData.price,
+            image: cartTestUtil.productData.image,
+            discountRate: cartTestUtil.productData.discountRate,
             store: {
-              id: storeData.id,
-              name: storeData.name,
-              address: storeData.address,
-              phoneNumber: storeData.phoneNumber,
-              content: storeData.content,
-              image: storeData.image,
+              id: cartTestUtil.storeData.id,
+              name: cartTestUtil.storeData.name,
+              address: cartTestUtil.storeData.address,
+              phoneNumber: cartTestUtil.storeData.phoneNumber,
+              content: cartTestUtil.storeData.content,
+              image: cartTestUtil.storeData.image,
             },
             stocks: expect.any(Array),
           },
           cart: {
-            id: cartData.id,
-            buyerId: buyerUserData.id,
+            id: cartTestUtil.cartData.id,
+            buyerId: cartTestUtil.buyerUserData.id,
           },
         });
       });
@@ -180,56 +166,56 @@ describe('장바구니 API 테스트', () => {
 
     describe('GET /api/cart/:id', () => {
       test('인증되지 않은 유저는 401을 반환한다', async () => {
-        const response = await request(app).get(`/api/cart/${cartItemData.id}`);
+        const response = await request(app).get(`/api/cart/${cartTestUtil.cartItemData.id}`);
         expect(response.status).toBe(401);
       });
 
       test('접근 권한이 없는 유저는 403을 반환한다', async () => {
-        await seedCartTestData();
-        const { agent } = await sellerUserLogin();
-        const response = await agent.get(`/api/cart/${cartItemData.id}`);
+        await cartTestUtil.seedCartTestData();
+        const { agent } = await cartTestUtil.sellerUserLogin();
+        const response = await agent.get(`/api/cart/${cartTestUtil.cartItemData.id}`);
         expect(response.status).toBe(403);
       });
 
       test('cartItemId가 존재하지 않는다면 404를 반환한다', async () => {
-        await seedCartTestData();
-        const { agent } = await buyerUserLogin();
+        await cartTestUtil.seedCartTestData();
+        const { agent } = await cartTestUtil.buyerUserLogin();
         const response = await agent.get(`/api/cart/errorId`);
 
         expect(response.status).toBe(404);
       });
       test('cartItemId로 검색하여 상품의 상세보기에 성공하면 200을 반환한다', async () => {
-        await seedCartTestData();
-        const { agent } = await buyerUserLogin();
-        const response = await agent.get(`/api/cart/${cartItemData.id}`);
+        await cartTestUtil.seedCartTestData();
+        const { agent } = await cartTestUtil.buyerUserLogin();
+        const response = await agent.get(`/api/cart/${cartTestUtil.cartItemData.id}`);
 
         expect(response.status).toBe(200);
         expect(response.body).toMatchObject({
-          id: cartItemData.id,
-          cartId: cartData.id,
-          productId: productData.id,
-          sizeId: sizeData.id,
+          id: cartTestUtil.cartItemData.id,
+          cartId: cartTestUtil.cartData.id,
+          productId: cartTestUtil.productData.id,
+          sizeId: cartTestUtil.sizeData.id,
           quantity: expect.any(Number),
           product: {
-            id: productData.id,
-            storeId: storeData.id,
-            name: productData.name,
-            price: productData.price,
-            image: productData.image,
-            discountRate: productData.discountRate,
+            id: cartTestUtil.productData.id,
+            storeId: cartTestUtil.storeData.id,
+            name: cartTestUtil.productData.name,
+            price: cartTestUtil.productData.price,
+            image: cartTestUtil.productData.image,
+            discountRate: cartTestUtil.productData.discountRate,
             store: {
-              id: storeData.id,
-              name: storeData.name,
-              address: storeData.address,
-              phoneNumber: storeData.phoneNumber,
-              content: storeData.content,
-              image: storeData.image,
+              id: cartTestUtil.storeData.id,
+              name: cartTestUtil.storeData.name,
+              address: cartTestUtil.storeData.address,
+              phoneNumber: cartTestUtil.storeData.phoneNumber,
+              content: cartTestUtil.storeData.content,
+              image: cartTestUtil.storeData.image,
             },
             stocks: expect.any(Array),
           },
           cart: {
-            id: cartData.id,
-            buyerId: buyerUserData.id,
+            id: cartTestUtil.cartData.id,
+            buyerId: cartTestUtil.buyerUserData.id,
           },
         });
       });
@@ -237,30 +223,30 @@ describe('장바구니 API 테스트', () => {
 
     describe('DELETE /api/cart/:id', () => {
       test('인증되지 않은 유저는 401을 반환한다', async () => {
-        await buyerUserLogin();
-        const response = await request(app).delete(`/api/cart/${cartItemData.id}`);
+        await cartTestUtil.buyerUserLogin();
+        const response = await request(app).delete(`/api/cart/${cartTestUtil.cartItemData.id}`);
         expect(response.status).toBe(401);
       });
 
       test('접근 권한이 없는 유저는 403을 반환한다', async () => {
-        await seedCartTestData();
-        const { agent } = await sellerUserLogin();
-        const response = await agent.delete(`/api/cart/${cartItemData.id}`);
+        await cartTestUtil.seedCartTestData();
+        const { agent } = await cartTestUtil.sellerUserLogin();
+        const response = await agent.delete(`/api/cart/${cartTestUtil.cartItemData.id}`);
         expect(response.status).toBe(403);
       });
 
       test('cartItemId가 존재하지 않는다면 404를 반환한다', async () => {
-        await seedCartTestData();
-        const { agent } = await buyerUserLogin();
+        await cartTestUtil.seedCartTestData();
+        const { agent } = await cartTestUtil.buyerUserLogin();
         const response = await agent.delete(`/api/cart/errorId`);
         expect(response.status).toBe(404);
       });
 
       test('cartItem 삭제에 성공하면 204를 반환한다', async () => {
-        await seedCartTestData();
-        const { agent } = await buyerUserLogin();
+        await cartTestUtil.seedCartTestData();
+        const { agent } = await cartTestUtil.buyerUserLogin();
 
-        const response = await agent.delete(`/api/cart/${cartItemData.id}`);
+        const response = await agent.delete(`/api/cart/${cartTestUtil.cartItemData.id}`);
 
         expect(response.status).toBe(204);
       });

--- a/src/routers/orderRouter.ts
+++ b/src/routers/orderRouter.ts
@@ -1,191 +1,21 @@
 import { Router } from 'express';
-import { prismaClient } from '../lib/prismaClient';
-import { PaymentStatus } from '@prisma/client';
+import {
+  createOrderController,
+  deleteOrderController,
+  getOrderByIdController,
+  getOrderListController,
+  updateOrderController,
+} from '../controllers/orderController';
+import authMiddleware from '../middlewares/authMiddleware';
+import asyncHandler from '../lib/asyncHandler';
+import { onlyBuyer } from '../middlewares/onlyMiddleware';
 
 const orderRouter = Router();
 
-orderRouter.post('/', async (req, res):Promise<void> => {
-    const data = req.body;
-
-    const order = await prismaClient.order.create({
-      data: {
-        userId: data.userId,
-        name: data.name,
-        phoneNumber: data.phoneNumber,
-        address: data.address,
-        subtotal: data.subtotal,
-        totalQuantity: data.totalQuantity,
-        usePoint: data.usePoint,
-      },
-    });
-
-    if (Array.isArray(data.orderItems) && data.orderItems.length > 0) {
-      const orderItemsData = data.orderItems.map((item:any) => ({
-        price: item.price,
-        quantity: item.quantity,
-        productId: item.productId,
-        sizeId: item.sizeId,
-        orderId: order.id,
-      }));
-      await prismaClient.orderItem.createMany({
-        data: orderItemsData,
-      });
-    }
-
-    await prismaClient.payment.create({
-      data: {
-        price: order.subtotal - order.usePoint,
-        status: PaymentStatus.CompletedPayment,
-        orderId: order.id,
-      },
-    });
-
-    const fullOrder = await prismaClient.order.findUnique({
-      where: { id: order.id },
-      include: {
-        orderItems: {
-          include: {
-            product: {
-              include: {
-                store: true,
-                stocks: {
-                  include: {
-                    size: true,
-                  },
-                },
-              },
-            },
-            size: true,
-          },
-        },
-        payments: true,
-      },
-    });
-
-    res.status(201).json(fullOrder);
-});
-
-orderRouter.get('/', async (req, res):Promise<void> => {
-    const orders = await prismaClient.order.findMany({
-      include: {
-        orderItems: {
-          include: {
-            product: {
-              include: {
-                store: true,
-                stocks: {
-                  include: {
-                    size: true,
-                  },
-                },
-              },
-            },
-            size: true,
-          },
-        },
-        payments: true,
-      },
-    });
-
-    res.status(200).json(orders);
-});
-
-orderRouter.get('/:id', async (req, res):Promise<void> => {
-    const { id } = req.params;
-
-    const order = await prismaClient.order.findUnique({
-      where: { id },
-      include: {
-        orderItems: {
-          include: {
-            product: {
-              include: {
-                store: true,
-                stocks: {
-                  include: {
-                    size: true,
-                  },
-                },
-              },
-            },
-            size: true,
-          },
-        },
-        payments: true,
-      },
-    });
-
-    if (!order) {
-     res.status(404).json({ error: 'Order not found' });
-     return;
-    }
-
-    res.status(200).json(order);
-});
-
-orderRouter.patch('/:id', async (req, res):Promise<void> => {
-  try {
-    const { id } = req.params;
-    const { name, phoneNumber, address, usePoint } = req.body;
-
-    const orderExists = await prismaClient.order.findUnique({ where: { id } });
-    if (!orderExists) {
-     res.status(404).json({ error: 'Order not found' });
-     return;
-    }
-
-    const updatedOrder = await prismaClient.order.update({
-      where: { id },
-      data: {
-        name,
-        phoneNumber,
-        address,
-        usePoint: Number(usePoint),
-      },
-      include: {
-        orderItems: {
-          include: {
-            product: {
-              include: {
-                store: true,
-                stocks: {
-                  include: {
-                    size: true,
-                  },
-                },
-              },
-            },
-            size: true,
-          },
-        },
-        payments: true,
-      },
-    });
-
-    res.status(200).json(updatedOrder);
-  } catch (error) {
-    console.error(error);
-    res.status(500).json({ error: '주문 수정 중 오류가 발생했습니다.' });
-  }
-});
-
-orderRouter.delete('/:id', async (req, res):Promise<void> => {
-  try {
-    const { id } = req.params;
-
-    const orderExists = await prismaClient.order.findUnique({ where: { id } });
-    if (!orderExists) {
-     res.status(404).json({ error: 'Order not found' });
-     return;
-    }
-
-    await prismaClient.order.delete({ where: { id } });
-
-    res.status(204).end();
-  } catch (error) {
-    console.error(error);
-    res.status(500).json({ error: '주문 삭제 중 오류가 발생했습니다.' });
-  }
-});
+orderRouter.post('/', authMiddleware, onlyBuyer, asyncHandler(createOrderController));
+orderRouter.get('/', authMiddleware, onlyBuyer, asyncHandler(getOrderListController));
+orderRouter.get('/:id', authMiddleware, onlyBuyer, asyncHandler(getOrderByIdController));
+orderRouter.patch('/:id', authMiddleware, onlyBuyer, asyncHandler(updateOrderController));
+orderRouter.delete('/:id', authMiddleware, onlyBuyer, asyncHandler(deleteOrderController));
 
 export default orderRouter;

--- a/src/services/orderService.ts
+++ b/src/services/orderService.ts
@@ -1,0 +1,93 @@
+import { CreateOrder, PaginationParams, PaginatedOrderList, updateOrderData } from '../types/order';
+import {
+  createOrder,
+  findUserId,
+  findProductByPrice,
+  getOrderList,
+  getOrderById,
+  updateOrder,
+  findUsePoint,
+  deleteOrder,
+  findPaymentByStatus,
+  findOrderById,
+} from '../repositories/orderRepository';
+import BadRequestError from '../lib/errors/BadRequestError';
+import NotFoundError from '../lib/errors/ProductNotFoundError';
+import { PaymentStatus } from '@prisma/client';
+
+export const createOrderService = async (data: CreateOrder, userId: string) => {
+  const user = await findUserId(data.userId);
+  if (!user) throw new BadRequestError('유저 정보가 존재하지 않습니다');
+  if (user.points < data.usePoint) throw new BadRequestError('포인트가 부족합니다');
+
+  const priceMap = await findProductByPrice(data.orderItems.map((item) => item.productId));
+
+  const currentUsePoint = await findUsePoint(userId);
+  if (currentUsePoint === null) throw new NotFoundError('user', userId);
+  if (data.usePoint > currentUsePoint)
+    throw new BadRequestError('사용할 수 있는 포인트를 초과했습니다.');
+
+  const subtotal = data.orderItems.reduce((sum, item) => {
+    const price = priceMap[item.productId];
+    if (price == null) throw new BadRequestError('상품 가격이 없습니다.');
+    return sum + price * item.quantity;
+  }, 0);
+
+  const totalQuantity = data.orderItems.reduce((sum, item) => sum + item.quantity, 0);
+
+  return await createOrder({
+    ...data,
+    subtotal,
+    totalQuantity,
+    priceMap,
+  });
+};
+
+export const getOrderListService = async (
+  userId: string,
+  params: PaginationParams,
+): Promise<PaginatedOrderList> => {
+  return await getOrderList(userId, params);
+};
+
+export const getOrderByIdService = async (orderId: string) => {
+  if (!orderId) throw new NotFoundError('order', orderId);
+
+  return await getOrderById(orderId);
+};
+
+export const updateOrderService = async (
+  updateData: updateOrderData,
+  orderId: string,
+  userId: string,
+) => {
+  const existingOrder = await findOrderById(orderId);
+  if (!existingOrder) {
+    throw new NotFoundError('주문', orderId);
+  }
+  const currentUsePoint = await findUsePoint(userId);
+  if (currentUsePoint === null) throw new NotFoundError('user', userId);
+  if (updateData.usePoint > currentUsePoint)
+    throw new BadRequestError('사용할 수 있는 포인트를 초과했습니다.');
+
+  const productId = updateData.orderItems.map((item) => item.productId);
+  const priceMap = await findProductByPrice(productId);
+
+  if (Object.keys(priceMap).length === 0)
+    throw new NotFoundError('product price', productId.join(', '));
+  for (const item of updateData.orderItems) {
+    if (priceMap[item.productId] == null) {
+      throw new NotFoundError('상품 가격', item.productId);
+    }
+  }
+  return await updateOrder(updateData, orderId, priceMap);
+};
+
+export const deleteOrderService = async (orderId: string) => {
+  const order = await findPaymentByStatus(orderId);
+  if (!order) throw new NotFoundError('orderId', orderId);
+  const paymentStatus = order.payments?.status;
+  if (paymentStatus !== PaymentStatus.WaitingPayment)
+    throw new BadRequestError('결제가 대기중인 상태에서만 삭제가 가능합니다.');
+  return await deleteOrder(orderId);
+};

--- a/src/structs/orderStructs.ts
+++ b/src/structs/orderStructs.ts
@@ -1,0 +1,31 @@
+import { coerce, integer, object, string, number, min, array, defaulted, optional, enums, nonempty, refine } from 'superstruct';
+import { PaymentStatus } from '@prisma/client';
+
+const phoneRegex = /^010-\d{4}-\d{4}$/;
+const Phone = refine(string(), 'Phone', (value) => phoneRegex.test(value));
+
+const OrderItem = object({
+  productId: nonempty(string()),
+  sizeId: nonempty(string()),
+  quantity: min(number(),1),
+})
+
+export const CreateOrderStuct = object({
+  name: nonempty(string()),
+  phoneNumber: nonempty(Phone),
+  address: nonempty(string()),
+  orderItems: array(OrderItem),
+  usePoint: defaulted(number(),0),
+})
+
+export const UpdateOrderStruct = CreateOrderStuct
+
+const integerString = coerce(integer(), string(), (value) => parseInt(value));
+
+export const OrderParamsStruct = object({
+  page: defaulted(integerString, 1),
+  pageSize: defaulted(integerString, 10),
+  orderBy: optional(enums(['recent', 'oldest'])),
+  status: optional(enums(Object.values(PaymentStatus))),
+});
+

--- a/src/types/cart.ts
+++ b/src/types/cart.ts
@@ -41,7 +41,7 @@ export type CartItemWithCart = Prisma.CartItemGetPayload<{
   }
 }>
 
-export interface UpdateCartItemData {
+export type UpdateCartItemData = {
   cartId: string;
   productId: string;
   sizeId: string;

--- a/src/types/order.ts
+++ b/src/types/order.ts
@@ -1,0 +1,71 @@
+import { Prisma, PaymentStatus } from '@prisma/client';
+
+export type CreateOrder = {
+  userId: string;
+  name: string;
+  phoneNumber: string;
+  address: string;
+  usePoint: number;
+  orderItems: {
+    productId: string;
+    sizeId: string;
+    quantity: number;
+  }[];
+};
+
+export type CreateOrderWithExtras = CreateOrder & {
+  subtotal: number;
+  totalQuantity: number;
+  priceMap: Record<string, number>;
+};
+
+export type OrderList = Prisma.OrderGetPayload<{
+  include: {
+    orderItems: {
+      include: {
+        product: {
+          include: {
+            store: true;
+            stocks: {
+              include: {
+                size: true;
+              };
+            };
+          };
+        };
+        size: true;
+      };
+    };
+    payments: true;
+  };
+}>;
+
+export type PaginationParams = {
+  page: number;
+  pageSize: number;
+  orderBy?: 'recent' | 'oldest';
+  status?: PaymentStatus;
+};
+
+export type PaginatedOrderList = {
+  data: OrderList[];
+  meta: {
+    limit: number;
+    page: number;
+    total: number;
+    totalPages: number;
+  };
+};
+
+export type updateOrderData = {
+  name: string;
+  phoneNumber: string;
+  address: string;
+  orderItems: {
+    productId: string;
+    sizeId: string;
+    quantity: number;
+    price: number;
+  }[];
+  usePoint: number;
+}


### PR DESCRIPTION
## 요구사항

### 기본
- [x] 주문 API 구현
- [x] 주문 테스트 코드 작성
- [x] 간단한 장바구니 리펙토링

## 주요 변경사항
- 간단하게 장바구니 리펙토링을 진행했습니다. 아직 더 리펙토링이 필요한 부분이 많이 남았습니다.
ex) 업데이트 부분에 트랜잭션 적용 등
- 주문 API 작성을 했습니다. 
- 장바구니와 동일하게 아직 리펙토링이 필요한 부분이 많이 남았습니다. 기본적인 기능 구현은 완료한 상태입니다.
- 주문이 생성되면 결제는 자동으로 완료가 됩니다 -> 결제가 완료되면 salesLog에 자동으로 기록을 쌓게됩니다.

## 팀원에게
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
- issues: #28
